### PR TITLE
update tee and remove two severe exceptions

### DIFF
--- a/.azure/install-tfs-clc.ps1
+++ b/.azure/install-tfs-clc.ps1
@@ -1,6 +1,6 @@
 param (
-    $ClientArchiveUrl = 'https://github.com/JetBrains/team-explorer-everywhere/releases/download/14.135.2/TEE-CLC-14.135.2.zip',
-    $ClientArchiveHash = '27B3346D1CDCD3E9431D21942BAB5C6EFBBB0AFC945B71BF332485FE214CB338',
+    $ClientArchiveUrl = 'https://github.com/JetBrains/team-explorer-everywhere/releases/download/14.135.3/TEE-CLC-14.135.3.zip',
+    $ClientArchiveHash = 'B6DF9DDB06E920924FDDA5678F33E7DEA268A343ED95C923B9CD72D06CF6C89A',
     $ClientArchiveStorage = "$PSScriptRoot/.download-cache",
     $ClientInstallPath = "$PSScriptRoot/.installed/tfs-clc"
 )

--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ project(":plugin") {
         tasks.register('prepareBackendSandbox', Copy) {
             dependsOn ":client:backend:installDist"
             from reactiveBackend
-            into layout.buildDirectory.dir("idea-sandbox/plugins/${project.name}")
+            into layout.buildDirectory.dir("idea-sandbox/IC-${ideaVersion}/plugins/${project.name}")
         }
         
         tasks.named('prepareSandbox') {

--- a/client/backend/build.gradle
+++ b/client/backend/build.gradle
@@ -7,7 +7,6 @@ plugins {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation project("tfs-sdk")
     implementation "com.jetbrains.rd:rd-framework:$rdGenVersion"
     

--- a/client/backend/build.gradle
+++ b/client/backend/build.gradle
@@ -14,6 +14,12 @@ dependencies {
     implementation 'junit:junit:4.12'
 }
 
+configurations {
+    all {
+        exclude group: 'org.jetbrains.kotlinx', module: 'kotlinx-coroutines-core-jvm'
+    }
+}
+
 compileKotlin {
     // Note: protocol dependency disabled due to rdgen compatibility issues  
     // Generated files are manually maintained

--- a/client/connector/build.gradle
+++ b/client/connector/build.gradle
@@ -14,7 +14,6 @@ sourceSets {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "com.jetbrains.rd:rd-framework:$rdGenVersion"
 }
 

--- a/client/connector/build.gradle
+++ b/client/connector/build.gradle
@@ -13,6 +13,12 @@ sourceSets {
     }
 }
 
+configurations {
+    all {
+        exclude group: 'org.jetbrains.kotlinx', module: 'kotlinx-coroutines-core-jvm'
+    }
+}
+
 dependencies {
     implementation "com.jetbrains.rd:rd-framework:$rdGenVersion"
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,0 +1,3 @@
+tasks.named('buildPlugin') {
+    dependsOn(tasks.named('prepareBackendSandbox'))
+}

--- a/plugin/src/com/microsoft/alm/common/utils/FileHelper.java
+++ b/plugin/src/com/microsoft/alm/common/utils/FileHelper.java
@@ -3,7 +3,14 @@
 
 package com.microsoft.alm.common.utils;
 
+import com.intellij.ide.projectView.impl.nodes.BasePsiNode;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.sun.jna.Platform;
+
+import java.util.stream.Stream;
 
 /**
  * Taken from team-explorer-everywhere: source/com.microsoft.tfs.util/src/com/microsoft/tfs/util/FileHelpers.java
@@ -135,5 +142,24 @@ public final class FileHelper {
 
         // This character is in our truth table.
         return VALID_NTFS_FILE_NAME_CHAR_TABLE[c];
+    }
+
+    public static VirtualFile[] getVirtualFiles(AnActionEvent anActionEvent) {
+        final var selectedObjects = anActionEvent.getData(PlatformDataKeys.SELECTED_ITEMS);
+        var files = selectedObjects != null ? Stream.of(selectedObjects).map(o -> o instanceof BasePsiNode psiFileNode ? psiFileNode.getVirtualFile() : null).filter(p -> p != null).toArray(VirtualFile[]::new) : new VirtualFile[0];
+
+        if (files == null || files.length == 0) {
+            files = anActionEvent.getData(LangDataKeys.VIRTUAL_FILE_ARRAY);
+        }
+
+        return files;
+    }
+
+    public static VirtualFile getOneVirtualFile(AnActionEvent anActionEvent) {
+        var files = getVirtualFiles(anActionEvent);
+        if (files != null && files.length != 0) {
+            return files[0];
+        }
+        return null;
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHolder.java
+++ b/plugin/src/com/microsoft/alm/plugin/external/reactive/ReactiveTfvcClientHolder.java
@@ -33,7 +33,7 @@ public class ReactiveTfvcClientHolder implements Disposable {
 
     public static Path getClientBackendPath() {
         return Paths.get(
-                Objects.requireNonNull(PluginManager.getPlugin(IdeaHelper.PLUGIN_ID)).getPath().getAbsolutePath(),
+                Objects.requireNonNull(PluginManager.getLoadedPlugins().stream().filter(p -> p.getPluginId().getIdString().equalsIgnoreCase(IdeaHelper.PLUGIN_ID.getIdString()) || p.getName().equalsIgnoreCase(IdeaHelper.PLUGIN_ID.getIdString())).findFirst().orElse(null)).getPath().getAbsolutePath(),
                 "backend");
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/actions/OpenFileInBrowserAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/actions/OpenFileInBrowserAction.java
@@ -5,7 +5,7 @@ package com.microsoft.alm.plugin.idea.common.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
@@ -15,6 +15,7 @@ import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ChangeListManager;
 import com.intellij.openapi.vfs.InvalidVirtualFileAccessException;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.microsoft.alm.common.utils.FileHelper;
 import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.plugin.idea.common.resources.Icons;
 import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
@@ -53,7 +54,7 @@ public class OpenFileInBrowserAction extends DumbAwareAction {
             return;
         }
 
-        final VirtualFile[] vFiles = anActionEvent.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY);
+        final VirtualFile[] vFiles = FileHelper.getVirtualFiles(anActionEvent);
         if (vFiles == null || vFiles.length == 0 || vFiles[0] == null) {
             // quick exit if no valid file selected
             presentation.setEnabledAndVisible(false);
@@ -144,8 +145,8 @@ public class OpenFileInBrowserAction extends DumbAwareAction {
 
     @Override
     public void actionPerformed(final AnActionEvent anActionEvent) {
-        final Project project = anActionEvent.getRequiredData(CommonDataKeys.PROJECT);
-        final VirtualFile virtualFile = anActionEvent.getRequiredData(CommonDataKeys.VIRTUAL_FILE);
+        final Project project = anActionEvent.getData(LangDataKeys.PROJECT);
+        final VirtualFile virtualFile = FileHelper.getOneVirtualFile(anActionEvent);
 
         final GitRepositoryManager manager = GitUtil.getRepositoryManager(project);
         final GitRepository gitRepository = manager.getRepositoryForFileQuick(virtualFile);

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/FeedbackAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/common/FeedbackAction.java
@@ -68,6 +68,7 @@ public class FeedbackAction extends AbstractAction {
 
         if (dialog.showAndGet()) {
             VcsNotifier.getInstance(project).notifySuccess(
+                    null,
                     TfPluginBundle.message(TfPluginBundle.KEY_FEEDBACK_DIALOG_TITLE),
                     TfPluginBundle.message(TfPluginBundle.KEY_FEEDBACK_NOTIFICATION));
         }

--- a/plugin/src/com/microsoft/alm/plugin/idea/common/ui/workitem/VcsWorkItemsModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/common/ui/workitem/VcsWorkItemsModel.java
@@ -130,6 +130,7 @@ public class VcsWorkItemsModel extends TabModelImpl<WorkItemsTableModel> {
                                     UrlHelper.getSpecificWorkItemURI(context.getTeamProjectURI(), workItem.getId()), String.valueOf(workItem.getId()), UrlHelper.getBranchURI(context.getUri(), branchName), branchName);
 
                             VcsNotifier.getInstance(project).notifyImportantInfo(
+                                    null,
                                     TfPluginBundle.message(wasWorkItemAssociated ? TfPluginBundle.KEY_WIT_ASSOCIATION_SUCCESSFUL_TITLE : TfPluginBundle.KEY_WIT_ASSOCIATION_FAILED_TITLE),
                                     notificationMsg,
                                     NotificationListener.URL_OPENING_LISTENER

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/actions/ImportAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/actions/ImportAction.java
@@ -56,7 +56,7 @@ public class ImportAction extends DumbAwareAction {
         } catch (Throwable t) {
             //unexpected error
             logger.warn("ImportAction doActionPerformed failed unexpected error", t);
-            VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_ACTIONS_IMPORT),
+            VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(TfPluginBundle.KEY_ACTIONS_IMPORT),
                     TfPluginBundle.message(TfPluginBundle.KEY_IMPORT_ERRORS_UNEXPECTED, t.getMessage()));
         }
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/extensions/GitCheckoutProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/extensions/GitCheckoutProvider.java
@@ -40,7 +40,7 @@ public class GitCheckoutProvider implements CheckoutProvider {
         } catch (Throwable t) {
             //unexpected error
             logger.warn("doCheckout failed unexpected error", t);
-            VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
+            VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
                     TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_ERRORS_UNEXPECTED, t.getMessage()));
         }
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/starters/SimpleCheckoutStarter.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/starters/SimpleCheckoutStarter.java
@@ -116,7 +116,7 @@ public class SimpleCheckoutStarter implements StarterBase {
         } catch (Throwable t) {
             //unexpected error occurred while doing simple checkout
             logger.warn("Azure DevOps commandline checkout failed due to an unexpected error", t);
-            VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
+            VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
                     TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_ERRORS_UNEXPECTED, t.getMessage()));
         }
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/branch/CreateBranchModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/branch/CreateBranchModel.java
@@ -177,7 +177,7 @@ public class CreateBranchModel extends AbstractModel {
                             gitRemoteUrl, true);
 
                     if (context == null) {
-                        VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(
+                        VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(
                                         TfPluginBundle.KEY_CREATE_BRANCH_ERRORS_AUTHENTICATION_FAILED_TITLE),
                                 TfPluginBundle.message(TfPluginBundle.KEY_ERRORS_AUTH_NOT_SUCCESSFUL, gitRemoteUrl));
                         return;
@@ -263,6 +263,7 @@ public class CreateBranchModel extends AbstractModel {
                 final String branchLink = String.format(UrlHelper.SHORT_HTTP_LINK_FORMATTER, UrlHelper.getBranchURI(context.getUri(), getBranchName()), getBranchName());
                 if (!ApplicationManager.getApplication().isUnitTestMode()) {
                     VcsNotifier.getInstance(project).notifyImportantInfo(
+                            null,
                             TfPluginBundle.message(TfPluginBundle.KEY_CREATE_BRANCH_DIALOG_SUCCESSFUL_TITLE),
                             TfPluginBundle.message(TfPluginBundle.KEY_CREATE_BRANCH_DIALOG_SUCCESSFUL_DESCRIPTION, branchLink),
                             NotificationListener.URL_OPENING_LISTENER
@@ -272,6 +273,7 @@ public class CreateBranchModel extends AbstractModel {
                 logger.warn("Create branch failed: {}", errorMessage);
                 if (!ApplicationManager.getApplication().isUnitTestMode()) {
                     VcsNotifier.getInstance(project).notifyError(
+                            null,
                             TfPluginBundle.message(TfPluginBundle.KEY_CREATE_BRANCH_DIALOG_FAILED_TITLE),
                             TfPluginBundle.message(
                                     TfPluginBundle.KEY_CREATE_BRANCH_ERRORS_BRANCH_CREATE_FAILED,

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/CreatePullRequestModel.java
@@ -717,9 +717,9 @@ public class CreatePullRequestModel extends AbstractModel {
 
     private void notifyError(final Project project, final String title, final String message) {
         if (message != null) {
-            VcsNotifier.getInstance(project).notifyError(title, message);
+            VcsNotifier.getInstance(project).notifyError(null, title, message);
         } else {
-            VcsNotifier.getInstance(project).notifyError(title, "");
+            VcsNotifier.getInstance(project).notifyError(null, title, "");
         }
     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/VcsPullRequestsModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/pullrequest/VcsPullRequestsModel.java
@@ -156,10 +156,10 @@ public class VcsPullRequestsModel extends TabModelImpl<PullRequestsTreeModel> {
     private void notifyOperationStatus(final boolean success, final String message) {
         if (success) {
             VcsNotifier.getInstance(project).notifySuccess(
-                    TfPluginBundle.message(TfPluginBundle.KEY_VCS_PR_TITLE), message);
+                    null, TfPluginBundle.message(TfPluginBundle.KEY_VCS_PR_TITLE), message);
         } else {
             VcsNotifier.getInstance(project).notifyError(
-                    TfPluginBundle.message(TfPluginBundle.KEY_VCS_PR_TITLE), message, "");
+                    null, TfPluginBundle.message(TfPluginBundle.KEY_VCS_PR_TITLE), message);
         }
 
         // Update the PR tab and any other UI that is listening for PR Changed events (even on failure updating the tab is a good idea)

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/simplecheckout/SimpleCheckoutModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/simplecheckout/SimpleCheckoutModel.java
@@ -179,7 +179,7 @@ public class SimpleCheckoutModel extends AbstractModel {
 
                     if (context == null) {
                         logger.warn("No context could be found");
-                        VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_ERRORS_AUTHENTICATION_FAILED_TITLE), TfPluginBundle.message(TfPluginBundle.KEY_ERRORS_AUTH_NOT_SUCCESSFUL, gitUrl));
+                        VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_ERRORS_AUTHENTICATION_FAILED_TITLE), TfPluginBundle.message(TfPluginBundle.KEY_ERRORS_AUTH_NOT_SUCCESSFUL, gitUrl));
                         return;
                     }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/git/ui/vcsimport/ImportPageModelImpl.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/git/ui/vcsimport/ImportPageModelImpl.java
@@ -275,7 +275,7 @@ public abstract class ImportPageModelImpl extends LoginPageModelImpl implements 
                 } finally {
                     if ((remoteUrlForDisplay != null && !remoteUrlForDisplay.isEmpty())) {
                         // Notify the user that we are done and provide a link to the repo
-                        VcsNotifier.getInstance(project).notifyImportantInfo(TfPluginBundle.message(TfPluginBundle.KEY_IMPORT_SUCCEEDED),
+                        VcsNotifier.getInstance(project).notifyImportantInfo(null, TfPluginBundle.message(TfPluginBundle.KEY_IMPORT_SUCCEEDED),
                                 TfPluginBundle.message(TfPluginBundle.KEY_IMPORT_SUCCEEDED_MESSAGE, project.getName(), remoteUrlForDisplay, repositoryName),
                                 NotificationListener.URL_OPENING_LISTENER);
                     }
@@ -593,7 +593,7 @@ public abstract class ImportPageModelImpl extends LoginPageModelImpl implements 
     }
 
     private void notifyImportError(final Project project, final String message) {
-        VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_IMPORT_FAILED), message, "");
+        VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(TfPluginBundle.KEY_IMPORT_FAILED), message);
     }
 
     @Override

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AddAction.java
@@ -28,7 +28,7 @@ import com.intellij.openapi.vcs.AbstractVcsHelper;
 import com.intellij.openapi.vcs.FileStatusManager;
 import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.vcsUtil.VcsUtil;
+import com.microsoft.alm.common.utils.FileHelper;
 import com.microsoft.alm.plugin.idea.common.resources.TfPluginBundle;
 import com.microsoft.alm.plugin.idea.tfvc.core.TFSVcs;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
@@ -48,7 +48,8 @@ public class AddAction extends DumbAwareAction {
     @Override
     public void actionPerformed(final AnActionEvent anActionEvent) {
         final Project project = anActionEvent.getData(CommonDataKeys.PROJECT);
-        final VirtualFile[] files = VcsUtil.getVirtualFiles(anActionEvent);
+
+        final VirtualFile[] files = FileHelper.getVirtualFiles(anActionEvent);
 
         final List<VcsException> errors = new ArrayList<VcsException>();
         ProgressManager.getInstance().runProcessWithProgressSynchronously(new Runnable() {
@@ -66,12 +67,13 @@ public class AddAction extends DumbAwareAction {
     @Override
     public void update(final AnActionEvent anActionEvent) {
         final Project project = anActionEvent.getProject();
-        final VirtualFile[] files = VcsUtil.getVirtualFiles(anActionEvent);
+        final VirtualFile[] files = FileHelper.getVirtualFiles(anActionEvent);
+
         anActionEvent.getPresentation().setEnabled(isEnabled(project, files));
     }
 
     private static boolean isEnabled(final Project project, final VirtualFile[] files) {
-        if (files.length == 0) {
+        if (files == null || files.length == 0) {
             return false;
         }
 
@@ -81,6 +83,7 @@ public class AddAction extends DumbAwareAction {
         }
 
         final FileStatusManager fileStatusManager = FileStatusManager.getInstance(project);
+
         return TfsFileUtil.findUnknownFiles(files, fileStatusManager);
     }
 }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AnnotateAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/AnnotateAction.java
@@ -6,8 +6,7 @@ package com.microsoft.alm.plugin.idea.tfvc.actions;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.ui.Messages;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.vcsUtil.VcsUtil;
+import com.microsoft.alm.common.utils.FileHelper;
 import com.microsoft.alm.common.utils.UrlHelper;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.idea.common.actions.OpenFileInBrowserAction;
@@ -31,7 +30,7 @@ public class AnnotateAction extends SingleItemAction {
 
     @Override
     public void update(@NotNull final AnActionEvent e) {
-        final VirtualFile file = VcsUtil.getOneVirtualFile(e);
+       final var file = FileHelper.getOneVirtualFile(e);
 
         // disable for directories
         if (file == null || file.isDirectory()) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/MultipleItemAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/MultipleItemAction.java
@@ -33,7 +33,7 @@ import com.intellij.openapi.vcs.FileStatusManager;
 import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.actions.VcsContextFactory;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.vcsUtil.VcsUtil;
+import com.microsoft.alm.common.utils.FileHelper;
 import com.microsoft.alm.helpers.Path;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.ItemInfo;
@@ -73,7 +73,7 @@ public abstract class MultipleItemAction<TItemInfo extends ItemInfo> extends Dum
     @Override
     public void update(final AnActionEvent anActionEvent) {
         final Project project = anActionEvent.getData(CommonDataKeys.PROJECT);
-        final VirtualFile[] files = VcsUtil.getVirtualFiles(anActionEvent);
+        final VirtualFile[] files = FileHelper.getVirtualFiles(anActionEvent);
         anActionEvent.getPresentation().setEnabled(isEnabled(project, files));
     }
 
@@ -85,7 +85,7 @@ public abstract class MultipleItemAction<TItemInfo extends ItemInfo> extends Dum
 
         final MultipleItemActionContext context = new MultipleItemActionContext();
         context.project = anActionEvent.getData(CommonDataKeys.PROJECT);
-        final VirtualFile[] files = VcsUtil.getVirtualFiles(anActionEvent);
+        final VirtualFile[] files = FileHelper.getVirtualFiles(anActionEvent);
 
         logger.info("Finding the list of selected files and getting itemInfos for each one");
         runWithProgress(context, new Runnable() {
@@ -107,10 +107,12 @@ public abstract class MultipleItemAction<TItemInfo extends ItemInfo> extends Dum
                 if (context.itemInfos.size() > 0) {
                     logger.info("Setting the defaultLocalPath and workingFolder");
                     context.defaultLocalPath = context.itemInfos.get(0).getLocalItem();
-                    context.isFolder = Path.directoryExists(context.defaultLocalPath);
-                    context.workingFolder = context.isFolder ?
-                            context.defaultLocalPath :
-                            Path.getDirectoryName(context.defaultLocalPath);
+                    if (context.defaultLocalPath != null) {
+                        context.isFolder = Path.directoryExists(context.defaultLocalPath);
+                        context.workingFolder = context.isFolder ?
+                                context.defaultLocalPath :
+                                Path.getDirectoryName(context.defaultLocalPath);
+                    }
                 }
             }
         }, TfPluginBundle.message(TfPluginBundle.KEY_ACTIONS_TFVC_LABEL_PROGRESS_GATHERING_INFORMATION));
@@ -174,7 +176,7 @@ public abstract class MultipleItemAction<TItemInfo extends ItemInfo> extends Dum
      * @return
      */
     protected boolean isEnabled(final Project project, final VirtualFile[] files) {
-        if (files.length == 0 || project == null) {
+        if (files == null || files.length == 0 || project == null) {
             return false;
         }
 

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/SingleItemAction.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/actions/SingleItemAction.java
@@ -35,6 +35,7 @@ import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.actions.VcsContextFactory;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcsUtil.VcsUtil;
+import com.microsoft.alm.common.utils.FileHelper;
 import com.microsoft.alm.plugin.context.ServerContext;
 import com.microsoft.alm.plugin.external.models.ItemInfo;
 import com.microsoft.alm.plugin.external.utils.CommandUtils;
@@ -71,7 +72,7 @@ public abstract class SingleItemAction extends DumbAwareAction {
 
     public void actionPerformed(final AnActionEvent e) {
         final Project project = e.getData(CommonDataKeys.PROJECT);
-        final VirtualFile file = VcsUtil.getOneVirtualFile(e);
+        final VirtualFile file = FileHelper.getOneVirtualFile(e);
 
         if (project == null || file == null) {
             // This shouldn't happen, but just in case
@@ -110,7 +111,7 @@ public abstract class SingleItemAction extends DumbAwareAction {
     }
 
     public void update(@NotNull final AnActionEvent e) {
-        e.getPresentation().setEnabled(isEnabled(e.getProject(), VcsUtil.getOneVirtualFile(e)));
+        e.getPresentation().setEnabled(isEnabled(e.getProject(), FileHelper.getOneVirtualFile(e)));
     }
 
     protected String getProgressMessage() {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCheckinEnvironment.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSCheckinEnvironment.java
@@ -45,7 +45,6 @@ import com.microsoft.alm.plugin.idea.common.utils.VcsHelper;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.TfsFileUtil;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.VersionControlPath;
 import com.microsoft.alm.plugin.idea.tfvc.core.tfs.operations.ScheduleForDeletion;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -200,7 +199,7 @@ public class TFSCheckinEnvironment implements CheckinEnvironment {
             final String changesetLink = String.format(UrlHelper.SHORT_HTTP_LINK_FORMATTER, UrlHelper.getTfvcChangesetURI(context.getUri().toString(), changesetNumber),
                     TfPluginBundle.message(TfPluginBundle.KEY_TFVC_CHECKIN_LINK_TEXT, changesetNumber));
             if (!ApplicationManager.getApplication().isUnitTestMode()) {
-                VcsNotifier.getInstance(myVcs.getProject()).notifyImportantInfo(TfPluginBundle.message(TfPluginBundle.KEY_TFVC_CHECKIN_SUCCESSFUL_TITLE),
+                VcsNotifier.getInstance(myVcs.getProject()).notifyImportantInfo(null, TfPluginBundle.message(TfPluginBundle.KEY_TFVC_CHECKIN_SUCCESSFUL_TITLE),
                         TfPluginBundle.message(TfPluginBundle.KEY_TFVC_CHECKIN_SUCCESSFUL_MSG, changesetLink), (notification, hyperlinkEvent) -> BrowserUtil.browse(hyperlinkEvent.getURL()));
             }
         } catch (Exception e) {

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
@@ -327,8 +327,9 @@ public class TFSVcs extends AbstractVcs {
                             logger.info("Notifying the user of the min version problem.");
                             // Notify the user that they should upgrade their version of the TF command line
                             VcsNotifier.getInstance(getProject()).notifyImportantWarning(
+                                    null,
                                     TfPluginBundle.message(TfPluginBundle.KEY_TFVC_TF_VERSION_WARNING_TITLE),
-                                    error, "");
+                                    error);
                         }
                     } catch (Exception e) {
                         logger.warn("Failed to warn user about min version of TF command line.", e);

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
@@ -98,7 +98,7 @@ public class TFSVcs extends AbstractVcs {
     private DiffProvider myDiffProvider;
     private TFSCheckinEnvironment myCheckinEnvironment;
     private UpdateEnvironment myUpdateEnvironment;
-    //private VcsVFSListener fileListener;
+    private VcsVFSListener fileListener;
     private TFSFileSystemListener tfsFileSystemListener;
     private CommittedChangesProvider<TFSChangeList, ChangeBrowserSettings> committedChangesProvider;
     private EditFileProvider myEditFileProvider;
@@ -126,7 +126,12 @@ public class TFSVcs extends AbstractVcs {
 
     @Override
     public void activate() {
-        //fileListener = new TFSFileListener(getProject(), this);
+        try {
+            fileListener = new TFSFileListener(getProject(), this);
+        } catch (Throwable throwable) {
+            logger.error("TFSFileListener cannot be initialized", throwable);
+        }
+
         if (tfsFileSystemListener == null) {
             tfsFileSystemListener = new TFSFileSystemListener(myProject);
         }
@@ -136,7 +141,10 @@ public class TFSVcs extends AbstractVcs {
 
     @Override
     public void deactivate() {
-        //Disposer.dispose(fileListener);
+        if (fileListener != null) {
+            Disposer.dispose(fileListener);
+        }
+
         tfsFileSystemListener.dispose();
         tfsFileSystemListener = null;
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TFSVcs.java
@@ -98,7 +98,7 @@ public class TFSVcs extends AbstractVcs {
     private DiffProvider myDiffProvider;
     private TFSCheckinEnvironment myCheckinEnvironment;
     private UpdateEnvironment myUpdateEnvironment;
-    private VcsVFSListener fileListener;
+    //private VcsVFSListener fileListener;
     private TFSFileSystemListener tfsFileSystemListener;
     private CommittedChangesProvider<TFSChangeList, ChangeBrowserSettings> committedChangesProvider;
     private EditFileProvider myEditFileProvider;
@@ -126,7 +126,7 @@ public class TFSVcs extends AbstractVcs {
 
     @Override
     public void activate() {
-        fileListener = new TFSFileListener(getProject(), this);
+        //fileListener = new TFSFileListener(getProject(), this);
         if (tfsFileSystemListener == null) {
             tfsFileSystemListener = new TFSFileSystemListener(myProject);
         }
@@ -136,7 +136,7 @@ public class TFSVcs extends AbstractVcs {
 
     @Override
     public void deactivate() {
-        Disposer.dispose(fileListener);
+        //Disposer.dispose(fileListener);
         tfsFileSystemListener.dispose();
         tfsFileSystemListener = null;
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcIntegrationEnabler.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/core/TfvcIntegrationEnabler.java
@@ -329,7 +329,7 @@ public class TfvcIntegrationEnabler extends VcsIntegrationEnabler {
             });
 
             if (success) {
-                vcsNotifier.notifySuccess("TFVC Import", 
+                vcsNotifier.notifySuccess(null, "TFVC Import",
                         TfPluginBundle.message(
                                 TfPluginBundle.KEY_TFVC_REPOSITORY_IMPORT_SUCCESS,
                                 projectDir.getPresentableUrl()));
@@ -337,6 +337,7 @@ public class TfvcIntegrationEnabler extends VcsIntegrationEnabler {
         } catch (Throwable error) {
             ourLogger.error(error);
             vcsNotifier.notifyError(
+                    null,
                     TfPluginBundle.message(
                             TfPluginBundle.KEY_TFVC_REPOSITORY_IMPORT_ERROR,
                             projectDir.getPresentableUrl()),

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/extensions/TfvcCheckoutProvider.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/extensions/TfvcCheckoutProvider.java
@@ -54,7 +54,7 @@ public class TfvcCheckoutProvider implements CheckoutProvider {
             controller.showModalDialog();
         } catch (Throwable t) {
             logger.warn("doCheckout failed unexpectedly", t);
-            VcsNotifier.getInstance(project).notifyError(TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
+            VcsNotifier.getInstance(project).notifyError(null, TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_DIALOG_TITLE),
                     TfPluginBundle.message(TfPluginBundle.KEY_CHECKOUT_ERRORS_UNEXPECTED, t.getMessage()));
         }
     }

--- a/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/workspace/WorkspaceModel.java
+++ b/plugin/src/com/microsoft/alm/plugin/idea/tfvc/ui/workspace/WorkspaceModel.java
@@ -340,6 +340,7 @@ public class WorkspaceModel extends AbstractModel {
                 // Notify the user of success and provide a link to sync the workspace
                 // (It doesn't make sense to tell the user we are done here if there is another thread still doing work)
                 VcsNotifier.getInstance(project).notifyImportantInfo(
+                        null,
                         TfPluginBundle.message(TfPluginBundle.KEY_WORKSPACE_DIALOG_NOTIFY_SUCCESS_TITLE),
                         TfPluginBundle.message(TfPluginBundle.KEY_WORKSPACE_DIALOG_NOTIFY_SUCCESS_MESSAGE),
                         (notification, hyperlinkEvent) -> syncWorkspaceAsync(serverContext, project, workspaceRootPath)
@@ -348,6 +349,7 @@ public class WorkspaceModel extends AbstractModel {
         } catch (final Throwable t) {
             //TODO on failure we could provide a link that reopened the dialog with the values they tried to save
             VcsNotifier.getInstance(project).notifyError(
+                    null,
                     TfPluginBundle.message(TfPluginBundle.KEY_WORKSPACE_DIALOG_NOTIFY_FAILURE_TITLE),
                     LocalizationServiceImpl.getInstance().getExceptionMessage(t));
         }
@@ -368,10 +370,12 @@ public class WorkspaceModel extends AbstractModel {
 
                     // Notify the user of a successful sync
                     VcsNotifier.getInstance(project).notifySuccess(
+                            null,
                             TfPluginBundle.message(TfPluginBundle.KEY_WORKSPACE_DIALOG_NOTIFY_SUCCESS_TITLE),
                             TfPluginBundle.message(TfPluginBundle.KEY_WORKSPACE_DIALOG_NOTIFY_SUCCESS_SYNC_MESSAGE));
                 } catch (final Throwable t) {
                     VcsNotifier.getInstance(project).notifyError(
+                            null,
                             TfPluginBundle.message(TfPluginBundle.KEY_WORKSPACE_DIALOG_NOTIFY_FAILURE_TITLE),
                             LocalizationServiceImpl.getInstance().getExceptionMessage(t));
                 }


### PR DESCRIPTION
Hi Vinnie,

the first commit is minimal, only update the internal tee to the latest jetbrains version.

The second commit eliminates two severe exceptions in the plugin, that practically disabled the tfs connection.

The third on fixes a breaking change in 2025.3, which enables again to show the notifications.